### PR TITLE
Beta: 10.0.1RC2, compare revision number & tests

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -104,9 +104,9 @@ return [
 	],
 	'beta' => [
 		'9.1' => [
-			'latest' => '10.0.1RC1',
-			'internalVersion' => '9.1.1RC1',
-			'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-10.0.1RC1.zip',
+			'latest' => '10.0.1RC2',
+			'internalVersion' => '9.1.1.2',
+			'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-10.0.1RC2.zip',
 			'web' => 'https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html',
 		],
 		'9.0.53' => [

--- a/src/Response.php
+++ b/src/Response.php
@@ -119,7 +119,9 @@ class Response {
 	 * @return string
 	 */
 	public function buildResponse() {
-		$completeCurrentVersion = $this->request->getMajorVersion().'.'.$this->request->getMinorVersion().'.'.$this->request->getMaintenanceVersion();
+		$completeCurrentVersion = $this->request->getMajorVersion().'.'.$this->request->getMinorVersion().'.'.$this->request->getMaintenanceVersion().'.'.$this->request->getRevisionVersion();
+
+		$completeCurrentVersion = rtrim($completeCurrentVersion, '.');
 
 		switch ($this->request->getChannel()) {
 			case 'production':

--- a/tests/integration/features/update.feature
+++ b/tests/integration/features/update.feature
@@ -82,26 +82,41 @@ Feature: Testing the update scenario of releases
     And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-10.0.0.zip"
     And URL to documentation is "https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html"
 
-  Scenario: Updating an up-to-date Nextcloud 9.1.0 on the production channel
+  Scenario: Updating an up-to-date Nextcloud 10.0.0 on the production channel
     Given There is a release with channel "production"
     And The received version is "9.1.0"
     When The request is sent
     Then The response is empty
 
-  Scenario: Updating an up-to-date Nextcloud 9.1.0 on the stable channel
+  Scenario: Updating an up-to-date Nextcloud 10.0.0 on the stable channel
     Given There is a release with channel "stable"
     And The received version is "9.1.0"
     When The request is sent
     Then The response is empty
 
-  Scenario: Updating an outdated Nextcloud 9.1.0 on the beta channel
+  Scenario: Updating an outdated Nextcloud 10.0.0 on the beta channel
     Given There is a release with channel "beta"
     And The received version is "9.1.0"
     When The request is sent
     Then The response is non-empty
-    And Update to version "9.1.1RC1" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-10.0.1RC1.zip"
+    And Update to version "9.1.1.2" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-10.0.1RC2.zip"
     And URL to documentation is "https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html"
+
+  Scenario: Updating an outdated Nextcloud 10.0.1RC1 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "9.1.1.1"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "9.1.1.2" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-10.0.1RC2.zip"
+    And URL to documentation is "https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html"
+
+  Scenario: Updating an up-to-date Nextcloud 10.0.1RC2 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "9.1.1.2"
+    When The request is sent
+    Then The response is empty
 
   Scenario: Updating an outdated Nextcloud 9.0 daily
     Given There is a release with channel "daily"


### PR DESCRIPTION
* 10.0.1RC2 as beta
* properly compares also the revision number
* more tests

cc @LukasReschke 