### PR TITLE
provide beta of 11.0 via beta channel

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -103,15 +103,15 @@ return [
 	],
 	'beta' => [
 		'11' => [
-			'latest' => '11.0 beta',
-			'internalVersion' => '11.0.0.4',
-			'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip',
+			'latest' => '11.0 beta 2',
+			'internalVersion' => '11.0.0.5',
+			'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta2.zip',
 			'web' => 'https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html',
 		],
 		'9.1' => [
-			'latest' => '11.0 beta',
-			'internalVersion' => '11.0.0.4',
-			'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip',
+			'latest' => '11.0 beta 2',
+			'internalVersion' => '11.0.0.5',
+			'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta2.zip',
 			'web' => 'https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html',
 		],
 		'9.0' => [

--- a/config/config.php
+++ b/config/config.php
@@ -102,11 +102,17 @@ return [
 		],
 	],
 	'beta' => [
+		'11' => [
+			'latest' => '11.0 beta',
+			'internalVersion' => '11.0.0.4',
+			'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip',
+			'web' => 'https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html',
+		],
 		'9.1' => [
-			'latest' => '10.0.1',
-			'internalVersion' => '9.1.1.5',
-			'downloadUrl' => 'https://download.nextcloud.com/server/releases/nextcloud-10.0.1.zip',
-			'web' => 'https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html',
+			'latest' => '11.0 beta',
+			'internalVersion' => '11.0.0.4',
+			'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip',
+			'web' => 'https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html',
 		],
 		'9.0' => [
 			'latest' => '10.0.1',

--- a/tests/integration/features/update.feature
+++ b/tests/integration/features/update.feature
@@ -113,3 +113,12 @@ Feature: Testing the update scenario of releases
     And the received build is "2019-10-19T18:44:30+00:00"
     When The request is sent
     Then The response is empty
+
+  Scenario: Updating an outdated Nextcloud 11.0.0.2 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "11.0.0.2"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "11.0.0.4" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip"
+    And URL to documentation is "https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html"

--- a/tests/integration/features/update.feature
+++ b/tests/integration/features/update.feature
@@ -61,8 +61,8 @@ Feature: Testing the update scenario of releases
     And The received version is "9.1.0"
     When The request is sent
     Then The response is non-empty
-    And Update to version "11.0.0.4" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip"
+    And Update to version "11.0.0.5" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta2.zip"
     And URL to documentation is "https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html"
 
   Scenario: Updating an outdated Nextcloud 10.0.1 on the beta channel
@@ -70,8 +70,8 @@ Feature: Testing the update scenario of releases
     And The received version is "9.1.1.1"
     When The request is sent
     Then The response is non-empty
-    And Update to version "11.0.0.4" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip"
+    And Update to version "11.0.0.5" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta2.zip"
     And URL to documentation is "https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html"
 
   Scenario: Updating an outdated Nextcloud 11.0.0 beta on the beta channel
@@ -79,13 +79,13 @@ Feature: Testing the update scenario of releases
     And The received version is "11.0.0.2"
     When The request is sent
     Then The response is non-empty
-    And Update to version "11.0.0.4" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip"
+    And Update to version "11.0.0.5" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta2.zip"
     And URL to documentation is "https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html"
 
   Scenario: Updating an up-to-date Nextcloud 11.0.0 on the beta channel
     Given There is a release with channel "beta"
-    And The received version is "11.0.0.4"
+    And The received version is "11.0.0.5"
     When The request is sent
     Then The response is empty
 

--- a/tests/integration/features/update.feature
+++ b/tests/integration/features/update.feature
@@ -61,22 +61,31 @@ Feature: Testing the update scenario of releases
     And The received version is "9.1.0"
     When The request is sent
     Then The response is non-empty
-    And Update to version "9.1.1.5" is available
-    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-10.0.1.zip"
-    And URL to documentation is "https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html"
+    And Update to version "11.0.0.4" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip"
+    And URL to documentation is "https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html"
 
   Scenario: Updating an outdated Nextcloud 10.0.1 on the beta channel
     Given There is a release with channel "beta"
     And The received version is "9.1.1.1"
     When The request is sent
     Then The response is non-empty
-    And Update to version "9.1.1.5" is available
-    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-10.0.1.zip"
-    And URL to documentation is "https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html"
+    And Update to version "11.0.0.4" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip"
+    And URL to documentation is "https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html"
 
-  Scenario: Updating an up-to-date Nextcloud 10.0.1 on the beta channel
+  Scenario: Updating an outdated Nextcloud 11.0.0 beta on the beta channel
     Given There is a release with channel "beta"
-    And The received version is "9.1.1.5"
+    And The received version is "11.0.0.2"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "11.0.0.4" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip"
+    And URL to documentation is "https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html"
+
+  Scenario: Updating an up-to-date Nextcloud 11.0.0 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "11.0.0.4"
     When The request is sent
     Then The response is empty
 
@@ -113,12 +122,3 @@ Feature: Testing the update scenario of releases
     And the received build is "2019-10-19T18:44:30+00:00"
     When The request is sent
     Then The response is empty
-
-  Scenario: Updating an outdated Nextcloud 11.0.0.2 on the beta channel
-    Given There is a release with channel "beta"
-    And The received version is "11.0.0.2"
-    When The request is sent
-    Then The response is non-empty
-    And Update to version "11.0.0.4" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-11.0.0beta.zip"
-    And URL to documentation is "https://docs.nextcloud.org/server/11/admin_manual/maintenance/manual_upgrade.html"


### PR DESCRIPTION
This provides the beta on the beta channel.

Deployed on https://updates.nextcloud.com/internal_updater_server/ for testing purposes.

cc @LukasReschke @nickvergessen 