### PR TITLE
Add the 12.0.0beta1 as first item

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -221,20 +221,22 @@ W0N7qv9mCgCHNclh6gPcTQ==',
 		],
 	],
 	'beta' => [
-		'11' => [
-			'90' => [
-				'latest' => '11.0.3',
-				'internalVersion' => '11.0.3.2',
-				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-11.0.3.zip',
+		'12' => [
+			'100' => [
+				'latest' => '12.0.0 Beta 1',
+				'internalVersion' => '12.0.0.16',
+				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-12.0.0beta1.zip',
 				'web' => 'https://docs.nextcloud.com/server/11/admin_manual/maintenance/upgrade.html',
 				'minPHPVersion' => '5.6',
-				'signature' => 'w0iy1vyJTo33IgQsr+fS9p+SNS8+VK5DLygY/m2lZi4odWrnu1EHw9yY6L0vQZx3
-Twu016evAkProWqbiRpOyplAfgiEZtnElRNf6YfqPJFcoSYDGrHronrBrYZr/1xX
-g2VxNQavCYZ5xKerWUyx5XfztURZsKRjd8+wy05AdCdS33JRnft6Z9Plt1i8zeZ9
-ZsQVCpfOVzrsFJ50SMLlewKl2ddGnIrn1woPicMA6biM7KKu38QU92L/f/Q4HqqK
-nUOMeuRVG/iT7nu4Qz0nzY8uE1GM7rfYiBxsRNTXtsjpzEOo3u4zEvC8jvJl136Q
-W0N7qv9mCgCHNclh6gPcTQ==',
+				'signature' => 'ho8LV/2eB0kSI89JJDTn8BtDnUBlAnFOVaDgcBim+N2yUUzsGy8Q+nWeffrL0bPU
+951fuSIHpjByfJxiSL5GipoT6555992PV6B8BckyTgVvWXxKGH2htQVdYUDTKfaB
+DCe59CvjNe4YR/qqBitTyJYeWqGD4FCrmAGmbQmhINm70H1TUl2zHBFi7rqFKwcw
+et3H3uSKf1UNGKx/HE1RSlGCukTc/o+UcwT7wAPlm3YfIMG9vrLX5s27JG6p5MlW
+N8VZ0VTtBZY0EAqedrHWZ4FxFOwmmxfdVoUbJgq8ZUlWBmAIj9t4vbHzXAVxu437
+6Jx1KWDwCnir1GssOSy2FQ==',
 			],
+		],
+		'11' => [
 			'10' => [
 				'latest' => '12.0.0 Beta 1',
 				'internalVersion' => '12.0.0.16',
@@ -247,6 +249,19 @@ DCe59CvjNe4YR/qqBitTyJYeWqGD4FCrmAGmbQmhINm70H1TUl2zHBFi7rqFKwcw
 et3H3uSKf1UNGKx/HE1RSlGCukTc/o+UcwT7wAPlm3YfIMG9vrLX5s27JG6p5MlW
 N8VZ0VTtBZY0EAqedrHWZ4FxFOwmmxfdVoUbJgq8ZUlWBmAIj9t4vbHzXAVxu437
 6Jx1KWDwCnir1GssOSy2FQ==',
+			],
+			'90' => [
+				'latest' => '11.0.3',
+				'internalVersion' => '11.0.3.2',
+				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-11.0.3.zip',
+				'web' => 'https://docs.nextcloud.com/server/11/admin_manual/maintenance/upgrade.html',
+				'minPHPVersion' => '5.6',
+				'signature' => 'w0iy1vyJTo33IgQsr+fS9p+SNS8+VK5DLygY/m2lZi4odWrnu1EHw9yY6L0vQZx3
+Twu016evAkProWqbiRpOyplAfgiEZtnElRNf6YfqPJFcoSYDGrHronrBrYZr/1xX
+g2VxNQavCYZ5xKerWUyx5XfztURZsKRjd8+wy05AdCdS33JRnft6Z9Plt1i8zeZ9
+ZsQVCpfOVzrsFJ50SMLlewKl2ddGnIrn1woPicMA6biM7KKu38QU92L/f/Q4HqqK
+nUOMeuRVG/iT7nu4Qz0nzY8uE1GM7rfYiBxsRNTXtsjpzEOo3u4zEvC8jvJl136Q
+W0N7qv9mCgCHNclh6gPcTQ==',
 			],
 		],
 		'9.1' => [

--- a/tests/integration/features/update.feature
+++ b/tests/integration/features/update.feature
@@ -290,6 +290,24 @@ Feature: Testing the update scenario of releases
   6Jx1KWDwCnir1GssOSy2FQ==
     """
 
+  Scenario: Updating an outdated staged Nextcloud 11.0.0 beta on the beta channel without an mtime
+    Given There is a release with channel "beta"
+    And The received version is "11.0.0.2"
+    And The received PHP version is "5.6.0"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "12.0.0.16" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-12.0.0beta1.zip"
+    And URL to documentation is "https://docs.nextcloud.com/server/11/admin_manual/maintenance/upgrade.html"
+    And The signature is
+    """
+  ho8LV/2eB0kSI89JJDTn8BtDnUBlAnFOVaDgcBim+N2yUUzsGy8Q+nWeffrL0bPU
+  951fuSIHpjByfJxiSL5GipoT6555992PV6B8BckyTgVvWXxKGH2htQVdYUDTKfaB
+  DCe59CvjNe4YR/qqBitTyJYeWqGD4FCrmAGmbQmhINm70H1TUl2zHBFi7rqFKwcw
+  et3H3uSKf1UNGKx/HE1RSlGCukTc/o+UcwT7wAPlm3YfIMG9vrLX5s27JG6p5MlW
+  N8VZ0VTtBZY0EAqedrHWZ4FxFOwmmxfdVoUbJgq8ZUlWBmAIj9t4vbHzXAVxu437
+  6Jx1KWDwCnir1GssOSy2FQ==
+    """
 
   Scenario: Updating an outdated Nextcloud 11.0.0 stable without PHP version
     Given There is a release with channel "stable"
@@ -328,9 +346,28 @@ Feature: Testing the update scenario of releases
   W0N7qv9mCgCHNclh6gPcTQ==
     """
 
-  Scenario: Updating an up-to-date Nextcloud 11.0.3 on the beta channel
+  Scenario: Updating an outdated Nextcloud 12.0.0 on the beta channel
     Given There is a release with channel "beta"
-    And The received version is "11.0.3.2"
+    And The received version is "12.0.0.15"
+    And The received PHP version is "5.6.0"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "12.0.0.16" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-12.0.0beta1.zip"
+    And URL to documentation is "https://docs.nextcloud.com/server/11/admin_manual/maintenance/upgrade.html"
+    And The signature is
+    """
+  ho8LV/2eB0kSI89JJDTn8BtDnUBlAnFOVaDgcBim+N2yUUzsGy8Q+nWeffrL0bPU
+  951fuSIHpjByfJxiSL5GipoT6555992PV6B8BckyTgVvWXxKGH2htQVdYUDTKfaB
+  DCe59CvjNe4YR/qqBitTyJYeWqGD4FCrmAGmbQmhINm70H1TUl2zHBFi7rqFKwcw
+  et3H3uSKf1UNGKx/HE1RSlGCukTc/o+UcwT7wAPlm3YfIMG9vrLX5s27JG6p5MlW
+  N8VZ0VTtBZY0EAqedrHWZ4FxFOwmmxfdVoUbJgq8ZUlWBmAIj9t4vbHzXAVxu437
+  6Jx1KWDwCnir1GssOSy2FQ==
+    """
+
+  Scenario: Updating an up-to-date Nextcloud 12.0.0 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "12.0.0.16"
     And The received PHP version is "5.6.0"
     When The request is sent
     Then The response is empty


### PR DESCRIPTION
The updater doesn't send the mtime itself so it will simply fallback to the first entry.

Fixes https://github.com/nextcloud/updater/issues/106

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>