### PR TITLE
Allow to provide different responses depending on the PHP version

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -25,7 +25,7 @@
  * 			'web' => 'https://docs.nextcloud.org/server/10/admin_manual/maintenance/upgrade.html',
  * 			// downloadUrl is an optional entry, if not specified the URL is generated using https://download.nextcloud.com/server/releases/nextcloud-'.$newVersion['latest'].'.zip
  * 			'downloadUrl' => 'https://download.nextcloud.com/foo.zip',
- * 			// internalVersion is an optional entry that defaults to latest if not set
+ * 			// internalVersion
  * 			'internalVersion' => '9.1.0'
  * 			// autoupdater is an optional boolean value to define whether the update should be just announced or also delivered
  * 			// defaults to true
@@ -40,7 +40,7 @@
  * 			'web' => 'https://docs.nextcloud.org/server/10/admin_manual/maintenance/upgrade.html',
  *			// downloadUrl is an optional entry, if not specified the URL is generated using https://download.nextcloud.com/server/releases/nextcloud-'.$newVersion['latest'].'.zip
  * 			'downloadUrl' => 'https://download.nextcloud.com/foo.zip',
- *			// internalVersion is an optional entry that defaults to latest if not set
+ *			// internalVersion
  * 			'internalVersion' => '11.0.0'
  * 			// autoupdater is an optional boolean value to define whether the update should be just announced or also delivered
  * 			// defaults to true
@@ -149,13 +149,20 @@ Fs4ECJ2ntpMtD4+2X0V4TXNZN3LPpDHE5vwTBHcJr52R0+s96731FYRUGesGmsHb
 xG0LjsK2vZOV4ZHT3tZPHGUV1Nrpfj5LIuCyPgn0w+XqTBm+AuF1W5MsgtDq0GOo
 /l4U06AGoCaWHiYAKXbHGg==',
 			],
-			// For PHP 5.4 users
-			'0' => [
+			'101' => [
 				'latest' => '10.0.6',
 				'internalVersion' => '9.1.6.1',
 				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-10.0.6.zip',
 				'web' => 'https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html',
 				'minPHPVersion' => '5.4',
+			],
+			'102' => [
+				'latest' => '11.0.6',
+				'internalVersion' => '11.0.6.1',
+				'downloadUrl' => 'https://nextcloud.com/outdated-php-5-4-5-5/',
+				'web' => 'https://nextcloud.com/outdated-php-5-4-5-5/',
+				'minPHPVersion' => '5.4',
+				'autoupdater' => '0',
 			],
 		],
 		'9.0' => [
@@ -222,13 +229,20 @@ Fs4ECJ2ntpMtD4+2X0V4TXNZN3LPpDHE5vwTBHcJr52R0+s96731FYRUGesGmsHb
 xG0LjsK2vZOV4ZHT3tZPHGUV1Nrpfj5LIuCyPgn0w+XqTBm+AuF1W5MsgtDq0GOo
 /l4U06AGoCaWHiYAKXbHGg==',
 			],
-			// For PHP 5.4 users
-			'0' => [
+			'101' => [
 				'latest' => '10.0.6',
 				'internalVersion' => '9.1.6.1',
 				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-10.0.6.zip',
 				'web' => 'https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html',
 				'minPHPVersion' => '5.4',
+			],
+			'102' => [
+				'latest' => '11.0.6',
+				'internalVersion' => '11.0.6.1',
+				'downloadUrl' => 'https://nextcloud.com/outdated-php-5-4-5-5/',
+				'web' => 'https://nextcloud.com/outdated-php-5-4-5-5/',
+				'minPHPVersion' => '5.4',
+				'autoupdater' => '0',
 			],
 		],
 		'9.0' => [
@@ -309,6 +323,21 @@ alihAAjVXU9kxK/YL40ZIK7MW2RwIXTOnNSzXbi4VqpX11UhshVvRqsR+xubg0jI
 Fs4ECJ2ntpMtD4+2X0V4TXNZN3LPpDHE5vwTBHcJr52R0+s96731FYRUGesGmsHb
 xG0LjsK2vZOV4ZHT3tZPHGUV1Nrpfj5LIuCyPgn0w+XqTBm+AuF1W5MsgtDq0GOo
 /l4U06AGoCaWHiYAKXbHGg==',
+			],
+			'101' => [
+				'latest' => '10.0.6',
+				'internalVersion' => '9.1.6.1',
+				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-10.0.6.zip',
+				'web' => 'https://docs.nextcloud.org/server/10/admin_manual/maintenance/manual_upgrade.html',
+				'minPHPVersion' => '5.4',
+			],
+			'102' => [
+				'latest' => '11.0.6',
+				'internalVersion' => '11.0.6.1',
+				'downloadUrl' => 'https://nextcloud.com/outdated-php-5-4-5-5/',
+				'web' => 'https://nextcloud.com/outdated-php-5-4-5-5/',
+				'minPHPVersion' => '5.4',
+				'autoupdater' => '0',
 			],
 		],
 		'9.0' => [

--- a/src/Response.php
+++ b/src/Response.php
@@ -34,8 +34,6 @@ class Response {
 		$searches[] = $this->request->getMajorVersion().'.'.$this->request->getMinorVersion();
 		// 4. Major
 		$searches[] = $this->request->getMajorVersion();
-		// 5. Major . 0
-		$searches[] = $this->request->getMajorVersion().'.0';
 		return $searches;
 	}
 
@@ -67,25 +65,17 @@ class Response {
 				foreach($newVersions as $chance => $updateOptions) {
 					$counter -= $chance;
 					if($instanceChance <= (100 - $counter)) {
+						// skip incompatible releases due to PHP version
+						if(isset($newVersions[$chance]['minPHPVersion']) && version_compare($newVersions[$chance]['minPHPVersion'], $phpVersion, '>')) {
+							continue;
+						}
+						// skip incompatible releases due to lower version number
+						if(version_compare($newVersions[$chance]['internalVersion'], $completeCurrentVersion, '<=')) {
+							continue;
+						}
 						$newVersion = $newVersions[$chance];
-						break;
+						break 2;
 					}
-				}
-
-				if (!isset($newVersion['internalVersion'])) {
-					$newVersion['internalVersion'] = $newVersion['latest'];
-				}
-
-				// skip incompatible releases
-				if(isset($newVersion['minPHPVersion']) && version_compare($newVersion['minPHPVersion'], $phpVersion, '>')) {
-					$newVersion = '';
-					continue;
-				}
-
-				if(version_compare($newVersion['internalVersion'], $completeCurrentVersion, '<=')) {
-					return '';
-				} else {
-					break;
 				}
 			}
 		}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -212,4 +212,14 @@ class FeatureContext implements Context, SnippetAcceptingContext {
             throw new \Exception('Response is not empty:' . PHP_EOL . PHP_EOL . $this->result);
         }
     }
+
+	/**
+	 * @Then Autoupdater is set to :arg1
+	 */
+	public function autoupdaterIsSetTo($autoupdaterValue) {
+		$autoupdater = $this->resultArray['autoupdater'];
+		if($autoupdater !== $autoupdaterValue) {
+			throw new \Exception("Expected autoupdate $autoupdaterValue does not equals $autoupdater");
+		}
+	}
 }

--- a/tests/integration/features/update.feature
+++ b/tests/integration/features/update.feature
@@ -127,7 +127,12 @@ Feature: Testing the update scenario of releases
     And the installation mtime is "60"
     And The received version is "9.1.6.1"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And Update to version "11.0.6.1" is available
+    And URL to download is "https://nextcloud.com/outdated-php-5-4-5-5/"
+    And URL to documentation is "https://nextcloud.com/outdated-php-5-4-5-5/"
+    And No signature is set
+    And Autoupdater is set to "0"
 
   Scenario: Updating an up-to-date staged Nextcloud 10.0.6 with PHP 5.6 on the production channel
     Given There is a release with channel "production"
@@ -155,7 +160,12 @@ Feature: Testing the update scenario of releases
     And the installation mtime is "60"
     And The received version is "9.1.6.1"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And Update to version "11.0.6.1" is available
+    And URL to download is "https://nextcloud.com/outdated-php-5-4-5-5/"
+    And URL to documentation is "https://nextcloud.com/outdated-php-5-4-5-5/"
+    And No signature is set
+    And Autoupdater is set to "0"
 
   Scenario: Updating an outdated Nextcloud 10.0.2 on the stable channel without PHP version
     Given There is a release with channel "stable"
@@ -223,13 +233,23 @@ Feature: Testing the update scenario of releases
     And The received version is "9.1.6.1"
     And The received PHP version is "5.4.0"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And Update to version "11.0.6.1" is available
+    And URL to download is "https://nextcloud.com/outdated-php-5-4-5-5/"
+    And URL to documentation is "https://nextcloud.com/outdated-php-5-4-5-5/"
+    And No signature is set
+    And Autoupdater is set to "0"
 
   Scenario: Updating an up-to-date Nextcloud 10.0.6 on the beta channel without sending PHP version
     Given There is a release with channel "beta"
     And The received version is "9.1.6.1"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And Update to version "11.0.6.1" is available
+    And URL to download is "https://nextcloud.com/outdated-php-5-4-5-5/"
+    And URL to documentation is "https://nextcloud.com/outdated-php-5-4-5-5/"
+    And No signature is set
+    And Autoupdater is set to "0"
 
   Scenario: Updating an outdated Nextcloud 10.0.1 on the beta channel with PHP 5.6
     Given There is a release with channel "beta"

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -46,7 +46,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 ',
 			],
 			[
-				'7',
+				'7.0.2',
 				'<?xml version="1.0" encoding="UTF-8"?>
 <nextcloud>
  <version>100.0.0.0</version>
@@ -58,7 +58,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 ',
 			],
 			[
-				'8',
+				'8.0.3',
 				'<?xml version="1.0" encoding="UTF-8"?>
 <nextcloud>
  <version>100.0.0.0</version>
@@ -82,7 +82,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 ',
 			],
 			[
-				'9',
+				'9.0.1',
 				'<?xml version="1.0" encoding="UTF-8"?>
 <nextcloud>
  <version>100.0.0.0</version>
@@ -160,10 +160,16 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			->expects($this->any())
 			->method('getMajorVersion')
 			->willReturn($version[0]);
-		if(isset($version[4])) {
+		if(isset($version[2])) {
 			$this->request
 				->expects($this->any())
 				->method('getMinorVersion')
+				->willReturn($version[2]);
+		}
+		if(isset($version[4])) {
+			$this->request
+				->expects($this->any())
+				->method('getMaintenanceVersion')
 				->willReturn($version[4]);
 		}
 
@@ -1135,6 +1141,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'11.0' => [
 				'100' => [
 					'latest' => '11.0.1',
+					'internalVersion' => '11.0.1',
 					'web' => 'https://docs.nextcloud.com/server/11/admin_manual/maintenance/upgrade.html',
 					'signature' => 'MySignature',
 				],
@@ -1142,48 +1149,56 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'8.2' => [
 				'100' => [
 					'latest' => '8.2.2',
+					'internalVersion' => '8.2.2',
 					'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 				],
 			],
 			'8.1' => [
 				'100' => [
 					'latest' => '8.1.5',
+					'internalVersion' => '8.1.5',
 					'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
 				],
 			],
 			'8.0' => [
 				'100' => [
 					'latest' => '8.0.10',
+					'internalVersion' => '8.0.10',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 				],
 			],
 			'8.0.7' => [
 				'100' => [
 					'latest' => '8.0.7.1',
+					'internalVersion' => '8.0.7.1',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 				],
 			],
 			'8.0.7.1' => [
 				'100' => [
 					'latest' => '8.0.8',
+					'internalVersion' => '8.0.8',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 				],
 			],
 			'8.0.8' => [
 				'100' => [
 					'latest' => '8.0.9',
+					'internalVersion' => '8.0.9',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 				],
 			],
 			'7' => [
 				'100' => [
 					'latest' => '7.0.12',
+					'internalVersion' => '7.0.12',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 				],
 			],
 			'6' => [
 				'100' => [
 					'latest' => '7.0.12',
+					'internalVersion' => '7.0.12',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 					'downloadUrl' => 'https://downloads.owncloud.com/foo.zip',
 				]
@@ -1238,6 +1253,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'8.2' => [
 				'100' => [
 					'latest' => '8.2.2',
+					'internalVersion' => '8.2.2',
 					'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 				],
@@ -1245,6 +1261,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'8.1' => [
 				'100' => [
 					'latest' => '8.1.5',
+					'internalVersion' => '8.1.5',
 					'web' => 'https://doc.owncloud.org/server/8.1/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 				],
@@ -1252,6 +1269,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'8.0' => [
 				'100' => [
 					'latest' => '8.0.10',
+					'internalVersion' => '8.0.10',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 				],
@@ -1259,6 +1277,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'8.0.7' => [
 				'100' => [
 					'latest' => '8.0.7.1',
+					'internalVersion' => '8.0.7.1',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 				],
@@ -1266,6 +1285,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'8.0.7.1' => [
 				'100' => [
 					'latest' => '8.0.8',
+					'internalVersion' => '8.0.8',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 				],
@@ -1273,6 +1293,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'8.0.8' => [
 				'100' => [
 					'latest' => '8.0.9',
+					'internalVersion' => '8.0.9',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 				],
@@ -1280,6 +1301,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'7' => [
 				'100' => [
 					'latest' => '7.0.12',
+					'internalVersion' => '7.0.12',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 				],
@@ -1287,6 +1309,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'6' => [
 				'100' => [
 					'latest' => '7.0.12',
+					'internalVersion' => '7.0.12',
 					'web' => 'https://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
 					'downloadUrl' => 'https://downloads.owncloud.com/foo.zip',
 					'autoupdater' => false,
@@ -1351,11 +1374,6 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 ',
 			],
 			[
-				'9901',
-				4,
-				'',
-			],
-			[
 				'',
 				4,
 				'<?xml version="1.0" encoding="UTF-8"?>
@@ -1382,12 +1400,14 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 			'8.2' => [
 				'95' => [
 					'latest' => '8.2.2',
+					'internalVersion' => '8.2.2',
 					'web' => 'https://doc.owncloud.org/server/8.2/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 					'minPHPVersion' => '5.4',
 				],
 				'5' => [
 					'latest' => '9.0.0',
+					'internalVersion' => '9.0.0',
 					'web' => 'https://doc.owncloud.org/server/9.0/admin_manual/maintenance/upgrade.html',
 					'autoupdater' => false,
 					'minPHPVersion' => '5.6',


### PR DESCRIPTION
This allows to specify "chances" above 100 percent, that are additional percentages (because we can not use multiple 100 entries).

Background for this is, that we should be able to have a different response for users on a given version depending on their PHP version. In this case Nextcloud 10 is the last version on PHP 5.4 and thus an upgrade to 11 will not be provided. Nevertheless the user should be informed about that problem and that they should upgrade to a newer PHP version.

This commit fixes how that constraints are handled:

* PHP version is now checked in the loop so that we properly skip incompatible ones
* NC version is also checked in the loop for the same reason
* a bug in the config reader is fixed where 9.1 had a fallback to 9.0 and thus serving (accidentially correct) answers
* a integration test is added for the disable autoupdater state

Signed-off-by: Morris Jobke <hey@morrisjobke.de>