### PR TITLE
Announce 21 only for instances on 20.0.12

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -154,7 +154,7 @@ M+LjFGQ3UrLdLEUspKcF0awiacjCuvMGF6ns835tSzzZA9EhlsTIcfpO0rLWZo2B
 h1nzVu4H9N0bSFDgo65oIQ==',
 			],
 		],
-		'20.0.11' => [
+		'20.0.12' => [
 			'100' => [
 				'latest' => '21.0.4',
 				'internalVersion' => '21.0.4.1',

--- a/tests/integration/features/stable.feature
+++ b/tests/integration/features/stable.feature
@@ -699,9 +699,9 @@ Feature: Testing the update scenario of stable releases
     """
 
 
-  Scenario: Updating the Nextcloud 20.0.11 on the stable channel
+  Scenario: Updating the Nextcloud 20.0.12 on the stable channel
     Given There is a release with channel "stable"
-    And The received version is "20.0.11.1"
+    And The received version is "20.0.12.1"
     And The received PHP version is "7.3.0"
     And the installation mtime is "11"
     When The request is sent


### PR DESCRIPTION
To announce 20.0.12 to everyone on 20.0.x. 100% of the instances on 20.0.12 are going to see the upgrade to 21 then.

~~Now announcing 21 to all 20 instances~~